### PR TITLE
docs: update doc to set default branch to main & remove release branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,8 @@ pip install py-vsys
 
 Install from Github
 ```bash
-pip install git+https://github.com/virtualeconomy/py-vsys.git@main
+pip install git+https://github.com/virtualeconomy/py-vsys.git
 ```
-
-`@main` is necessary as the default branch is `develop`
 
 ### Pipenv
 
@@ -46,10 +44,8 @@ pipenv install py-vsys
 
 Install from Github
 ```bash
-pipenv install git+https://github.com/virtualeconomy/py-vsys.git@main#egg=py_vsys
+pipenv install git+https://github.com/virtualeconomy/py-vsys.git#egg=py_vsys
 ```
-
-`@main` is necessary as the default branch is `develop`
 
 ## Quick Example
 

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -36,9 +36,8 @@
 To contribute, please work on a forked repo and create a PR from the forked repo to the `develop` branch of the main repo.
 
 The main repo will have 3 branches:
-- **main**: The latest version that is released.
-- **develop**: The latest version that is being worked on. **The default branch**.
-- **release**: The version that is going to be released. The **release** branch shall be checked out from the **develop** branch and be tested. All fixes shall be committed to the **release** branch directly. When the test passed, the **release** branch shall be merged into the **main** branch with a tag of the released version and be merged to the **develop** branch as well if there is any fixes commits.
+- `main`: The latest version that is released.
+- `develop`: The latest version that is being worked on. 
 
 
 ## Set Up Development Environment


### PR DESCRIPTION
## What Does This PR Do
Update docs to set the default branch to `main` & simplify the releasing flow with removing the `release` branch in the doc 

## How Is The Changes Tested
No tests are required.

## Checklist

- [x] Selected assignees
- [x] Selected reviewers (if you are not the admin of the repo)
- [x] The PR name follows [the convention](https://github.com/virtualeconomy/py-vsys/blob/develop/doc/dev.md#branch--pr-naming-convention)
