### PR TITLE
fix: fix the wrong tok unit

### DIFF
--- a/py_vsys/contract/v_option_ctrt.py
+++ b/py_vsys/contract/v_option_ctrt.py
@@ -567,7 +567,7 @@ class VOptionCtrt(Ctrt):
             md.Token: The amount of the base tokens in the pool.
         """
         raw_val = await self._query_db_key(self.DBKey.for_token_collected())
-        return md.Token(raw_val, await self.target_tok_unit)
+        return md.Token(raw_val, await self.base_tok_unit)
 
     @property
     async def base_tok_unit(self) -> int:


### PR DESCRIPTION
## What Does This PR Do
fix the wrong tok unit

## How Is The Changes Tested


## Checklist

- [x] Selected assignees
- [x] Selected reviewers (if you are not the admin of the repo)
- [x] The PR name follows [the convention](https://github.com/virtualeconomy/py-vsys/blob/develop/doc/dev.md#branch--pr-naming-convention)
